### PR TITLE
Turn off Hasura Console UI

### DIFF
--- a/docker/envs/local/hasura
+++ b/docker/envs/local/hasura
@@ -1,4 +1,4 @@
 HASURA_GRAPHQL_ADMIN_SECRET=dev_only_password
 HASURA_GRAPHQL_DATABASE_URL=postgres://zagrajmy:zagrajmy@postgres:5432/zagrajmy_dev
-HASURA_GRAPHQL_ENABLE_CONSOLE=true
+HASURA_GRAPHQL_ENABLE_CONSOLE=false
 HASURA_GRAPHQL_ENABLED_LOG_TYPES=startup,http-log,webhook-log,websocket-log,query-log

--- a/docker/envs/prod/hasura
+++ b/docker/envs/prod/hasura
@@ -1,4 +1,4 @@
 HASURA_GRAPHQL_ADMIN_SECRET=dev_only_password
 HASURA_GRAPHQL_DATABASE_URL=postgres://zagrajmy:zagrajmy@db:5432/zagrajmy_dev
-HASURA_GRAPHQL_ENABLE_CONSOLE=true
+HASURA_GRAPHQL_ENABLE_CONSOLE=false
 HASURA_GRAPHQL_ENABLED_LOG_TYPES=startup,http-log,webhook-log,websocket-log,query-log


### PR DESCRIPTION
The docs were actually right. We'll turn this off so we can't corrupt the migrations directory.